### PR TITLE
Fix benchmark delegate_with_auto_compound weights

### DIFF
--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -1171,8 +1171,8 @@ benchmarks! {
 		let x in 0..(<<T as Config>::MaxTopDelegationsPerCandidate as Get<u32>>::get()
 		+ <<T as Config>::MaxBottomDelegationsPerCandidate as Get<u32>>::get());
 		let y in 0..<<T as Config>::MaxTopDelegationsPerCandidate as Get<u32>>::get()
-		+ <<T as Config>::MaxBottomDelegationsPerCandidate as Get<u32>>::get();
-		let z in 0..<<T as Config>::MaxDelegationsPerDelegator as Get<u32>>::get();
+		+ <<T as Config>::MaxBottomDelegationsPerCandidate as Get<u32>>::get() - 1;
+		let z in 0..<<T as Config>::MaxDelegationsPerDelegator as Get<u32>>::get() - 1;
 
 		use crate::auto_compound::AutoCompoundDelegations;
 
@@ -1240,7 +1240,7 @@ benchmarks! {
 		Pallet::<T>::delegate_with_auto_compound(
 			RawOrigin::Signed(prime_delegator.clone()).into(),
 			prime_candidate.clone(),
-			min_delegator_stake,
+			min_delegator_stake * 2u32.into(),
 			Percent::from_percent(50),
 			x,
 			y,


### PR DESCRIPTION
### What does it do?

The benchmark of `delegate_with_auto_compound` produces the following weight after this fix.

```rust
    /// Storage: System Account (r:1 w:1)
    /// Proof: System Account (max_values: None, max_size: Some(132), added: 2607, mode: MaxEncodedLen)
    /// Storage: ParachainStaking DelegatorState (r:1 w:1)
    /// Proof Skipped: ParachainStaking DelegatorState (max_values: None, max_size: None, mode: Measured)
    /// Storage: ParachainStaking CandidateInfo (r:1 w:1)
    /// Proof Skipped: ParachainStaking CandidateInfo (max_values: None, max_size: None, mode: Measured)
    /// Storage: ParachainStaking AutoCompoundingDelegations (r:1 w:1)
    /// Proof Skipped: ParachainStaking AutoCompoundingDelegations (max_values: None, max_size: None, mode: Measured)
    /// Storage: ParachainStaking TopDelegations (r:1 w:1)
    /// Proof Skipped: ParachainStaking TopDelegations (max_values: None, max_size: None, mode: Measured)
    /// Storage: ParachainStaking BottomDelegations (r:1 w:1)
    /// Proof Skipped: ParachainStaking BottomDelegations (max_values: None, max_size: None, mode: Measured)
    /// Storage: ParachainStaking CandidatePool (r:1 w:1)
    /// Proof Skipped: ParachainStaking CandidatePool (max_values: Some(1), max_size: None, mode: Measured)
    /// Storage: Balances Locks (r:1 w:1)
    /// Proof: Balances Locks (max_values: None, max_size: Some(1299), added: 3774, mode: MaxEncodedLen)
    /// Storage: ParachainStaking Total (r:1 w:1)
    /// Proof Skipped: ParachainStaking Total (max_values: Some(1), max_size: None, mode: Measured)
    fn delegate_with_auto_compound(x: u32, y: u32, z: u32) -> Weight {
        // Proof Size summary in bytes:
        //  Measured:  `0 + x * (84 ±0) + y * (33 ±0) + z * (114 ±0)`
        //  Estimated: `127262 + x * (367 ±0) + y * (73 ±0) + z * (230 ±1)`
        // Minimum execution time: 88_000 nanoseconds.
        Weight::from_parts(149_011_098, 127262)
            // Standard Error: 34_531
            .saturating_add(Weight::from_ref_time(535_456).saturating_mul(z.into()))
            .saturating_add(T::DbWeight::get().reads(8_u64))
            .saturating_add(T::DbWeight::get().writes(8_u64))
			.saturating_add(Weight::from_proof_size(367).saturating_mul(x.into()))
			.saturating_add(Weight::from_proof_size(73).saturating_mul(y.into()))
			.saturating_add(Weight::from_proof_size(230).saturating_mul(z.into()))
    }
```

### What important points reviewers should know?

Before the fix the weight included a very large proof of validity size:

```rust
    /// Storage: System Account (r:1 w:1)
    /// Proof: System Account (max_values: None, max_size: Some(132), added: 2607, mode: MaxEncodedLen)
    /// Storage: ParachainStaking DelegatorState (r:1 w:1)
    /// Proof Skipped: ParachainStaking DelegatorState (max_values: None, max_size: None, mode: Measured)
    /// Storage: ParachainStaking CandidateInfo (r:1 w:1)
    /// Proof Skipped: ParachainStaking CandidateInfo (max_values: None, max_size: None, mode: Measured)
    /// Storage: ParachainStaking AutoCompoundingDelegations (r:1 w:1)
    /// Proof Skipped: ParachainStaking AutoCompoundingDelegations (max_values: None, max_size: None, mode: Measured)
    /// Storage: ParachainStaking BottomDelegations (r:1 w:1)
    /// Proof Skipped: ParachainStaking BottomDelegations (max_values: None, max_size: None, mode: Measured)
    /// Storage: Balances Locks (r:1 w:1)
    /// Proof: Balances Locks (max_values: None, max_size: Some(1299), added: 3774, mode: MaxEncodedLen)
    /// Storage: ParachainStaking Total (r:1 w:1)
    /// Proof Skipped: ParachainStaking Total (max_values: Some(1), max_size: None, mode: Measured)
    /// Storage: ParachainStaking TopDelegations (r:1 w:1)
    /// Proof Skipped: ParachainStaking TopDelegations (max_values: None, max_size: None, mode: Measured)
    /// Storage: ParachainStaking CandidatePool (r:1 w:1)
    /// Proof Skipped: ParachainStaking CandidatePool (max_values: Some(1), max_size: None, mode: Measured)
    fn delegate_with_auto_compound(x: u32, y: u32, z: u32) -> Weight {
        // Proof Size summary in bytes:
        //  Measured:  `0 + x * (82 ±0) + y * (33 ±0) + z * (60 ±0)`
        //  Estimated: `242081338576 + y * (2502655457532 ±0) + z * (196 ±2) + x * (168 ±0)`
        // Minimum execution time: 124_371 nanoseconds.
        Weight::from_parts(117_410_630, 242081338576)
            // Standard Error: 2_928
            .saturating_add(Weight::from_ref_time(80_456).saturating_mul(x.into()))
            // Standard Error: 2_928
            .saturating_add(Weight::from_ref_time(85_084).saturating_mul(y.into()))
            // Standard Error: 10_219
            .saturating_add(Weight::from_ref_time(362_814).saturating_mul(z.into()))
            .saturating_add(T::DbWeight::get().reads(8_u64))
            .saturating_add(T::DbWeight::get().writes(8_u64))
            .saturating_add(Weight::from_proof_size(2502655457532).saturating_mul(y.into()))
            .saturating_add(Weight::from_proof_size(196).saturating_mul(z.into()))
            .saturating_add(Weight::from_proof_size(168).saturating_mul(x.into()))
    }
```

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

https://github.com/moonbeam-foundation/moonbeam/pull/2336

### What value does it bring to the blockchain users?
